### PR TITLE
fix(homepage): adjust css filter and mix mode

### DIFF
--- a/src/scss/pages/_homepage.scss
+++ b/src/scss/pages/_homepage.scss
@@ -115,24 +115,43 @@
 .intro__video-wrapper {
   @extend %video-background-layer-0;
 
-  filter: light-dark(grayscale(100%) contrast(2), grayscale(100%));
   left: 0;
   margin: 0 auto;
   mask-image: linear-gradient(hsl(0, 0%, 0%) 75%, hsla(0, 0%, 0%, 0) 99%);
   max-height: 70rem;
   min-height: min(60rem, 60vh);
-  mix-blend-mode: light-dark(multiply, overlay);
-  opacity: light-dark(.35, 1);
   overflow: hidden;
   position: absolute;
   right: 0;
   top: 0;
+
+  &:after {
+    background-image: linear-gradient(
+      var(--background-direction),
+      var(--background-start-color) 0%,
+      var(--background-end-color) 100%,
+    );
+    content: "";
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 100vw;
+  }
 }
 
 .intro__video {
+  @extend %video-background-layer-1;
+
+  filter: light-dark(grayscale(100%) contrast(2), grayscale(100%));
   margin-left: 50%;
   min-height: 60rem;
   min-width: 100vw;
+  mix-blend-mode: light-dark(multiply, overlay);
+  opacity: light-dark(.35, 1);
+  position: relative;
   transform: translateX(-50%);
 }
 


### PR DESCRIPTION
Adjust CSS filter and mix mode for the video player so that it properly blends into the background on Safari for macOS

(cherry picked from commit 22c38d3dcecde0f0ed0ed94a9edc9c0ddccba5b7)

|         | Before | After |
| ------- | ------ | ----- |
| Safari macOS ![github-spacer](https://github.com/user-attachments/assets/10175c24-af96-4e68-a0c0-5de93ded6227) | ![CleanShot 2025-02-01 at 21 46 53](https://github.com/user-attachments/assets/41684efc-da15-4b41-aa99-8193dbf06a76) | ![CleanShot 2025-02-01 at 21 43 06](https://github.com/user-attachments/assets/8634d093-3d25-4d55-b0d8-ddab66750633) |
| Firefox macOS | ![CleanShot 2025-02-01 at 21 46 23](https://github.com/user-attachments/assets/0c8e0aa4-0a66-4226-b387-fb88a1bb9f8f) | ![CleanShot 2025-02-01 at 21 48 00](https://github.com/user-attachments/assets/2f4e0728-f025-494b-b8c6-3339ddc67573) |
| Safari iOS | ![IMG_4755](https://github.com/user-attachments/assets/53a7f1da-6f72-405b-9ebd-daa2fc7c4fe3) | ![IMG_BD24FA87DE36-1](https://github.com/user-attachments/assets/07edafb1-e4c7-4b07-8393-f3200c4e3795) |